### PR TITLE
feat: send email to the user on ID verification

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -17,3 +17,5 @@ auth.User:
   ".. pii_retirement:" : consumer_api
 contenttypes.ContentType:
   ".. no_pii:": "This model has no PII"
+sites.Site:
+  ".. no_pii:": "This model has no PII"

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,11 @@ Overview
 
 This app allows students to submit a Photo ID instead of using their webcam to prove their identity
 
+Compatibility
+-------------
+
+This app is compatible with `juniper` and `koa` releases of `Open edX`.
+
 Usage
 -----
 

--- a/custom_student_verification/__init__.py
+++ b/custom_student_verification/__init__.py
@@ -4,6 +4,6 @@ Custom Django app for student verification.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'
 
 default_app_config = 'custom_student_verification.apps.CustomStudentVerificationConfig'  # pylint: disable=invalid-name

--- a/custom_student_verification/compat.py
+++ b/custom_student_verification/compat.py
@@ -19,3 +19,51 @@ def get_manual_verification_model():
         return ManualVerification
     except ImportError:
         return object
+
+
+def get_language_key():
+    """
+    Get the LANGUAGE_KEY from openedx.
+    """
+    try:
+        from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+        return LANGUAGE_KEY
+    except ImportError:
+        return 'perf-lang'
+
+
+def get_user_preference_model():
+    """
+    Get the UserPreference model.
+    """
+    try:
+        from openedx.core.djangoapps.user_api.models import UserPreference
+        return UserPreference
+    except ImportError:
+        return object
+
+
+def get_base_template_context(site):
+    """
+    Compatibility function for the get_base_template_context.
+
+    Returns the context if get_base_template_context is imported else
+    returns empty dictionary.
+    """
+    try:
+        from openedx.core.djangoapps.ace_common.template_context import get_base_template_context as get_context
+        return get_context(site)
+    except ImportError:
+        return {}
+
+
+def get_base_message_type():
+    """
+    Get BaseMessageType class.
+    """
+    try:
+        from openedx.core.djangoapps.ace_common.message import BaseMessageType
+        return BaseMessageType
+    except ImportError:
+        from edx_ace.message import MessageType
+        return MessageType

--- a/custom_student_verification/message_types.py
+++ b/custom_student_verification/message_types.py
@@ -1,0 +1,34 @@
+"""
+ACE message types for the custom_student_verfication app.
+"""
+from custom_student_verification.compat import get_base_message_type
+
+BaseMessageType = get_base_message_type()
+
+
+class VerificationApproved(BaseMessageType):
+    """
+    A message to the learner when their ID verification has been approved.
+    """
+
+    APP_LABEL = 'custom_student_verification'
+    NAME = 'verificationapproved'
+
+    def __init__(self, *args, **kwargs):
+        """Init method."""
+        super().__init__(*args, **kwargs)
+        self.options['transactional'] = True
+
+
+class VerificationRejected(BaseMessageType):
+    """
+    A message to the learner when their ID verification has been rejected.
+    """
+
+    APP_LABEL = 'custom_student_verification'
+    NAME = 'verificationrejected'
+
+    def __init__(self, *args, **kwargs):
+        """Init method."""
+        super().__init__(*args, **kwargs)
+        self.options['transactional'] = True

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/body.html
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/body.html
@@ -1,0 +1,35 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+  <tr>
+    <td>
+      <h1>
+        {% trans "ID Verification Approved" as tmsg %}{{ tmsg | force_escape }}
+      </h1>
+      <p style="color: rgba(0,0,0,.75);">
+        {% filter force_escape %}
+          {% blocktrans %}Hello {{ full_name }},{% endblocktrans %}
+        {% endfilter %}
+      </p>
+      <p style="color: rgba(0,0,0,.75);">
+        {% filter force_escape %}
+          {% blocktrans %}Your {{ platform_name }} ID verification photos have been approved.{% endblocktrans %}
+        {% endfilter %}
+        <br/>
+      </p>
+
+      <p>
+        {% trans "Enjoy your studies," as tmsg %}{{ tmsg | force_escape }}
+        <br/>
+        {% filter force_escape %}
+          {% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}
+        {% endfilter %}
+      </p>
+
+    </td>
+  </tr>
+</table>
+{% endblock %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/body.txt
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/body.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Hello {{full_name}}, {% endblocktrans %}
+{% blocktrans %}Your {{ platform_name }} ID verification photos have been approved.{% endblocktrans %}
+
+{% trans "Enjoy your studies," %}
+{% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}
+{% endautoescape %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/from_name.txt
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/from_name.txt
@@ -1,0 +1,1 @@
+{{ platform_name }}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/head.html
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/head.html
@@ -1,0 +1,1 @@
+{% extends 'ace_common/edx_ace/common/base_head.html' %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/subject.txt
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationapproved/email/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Your {{ platform_name }} ID verification was approved!{% endblocktrans %}
+{% endautoescape %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/body.html
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/body.html
@@ -1,0 +1,42 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+  <tr>
+    <td>
+      <h1>
+        {% trans "ID Verification Rejected" as tmsg %}{{ tmsg | force_escape }}
+      </h1>
+      <p style="color: rgba(0,0,0,.75);">
+        {% filter force_escape %}
+          {% blocktrans %}Hello {{ full_name }},{% endblocktrans %}
+        {% endfilter %}
+      </p>
+      <p style="color: rgba(0,0,0,.75);">
+        {% filter force_escape %}
+          {% blocktrans %}Your {{ platform_name }} ID verification photos have been rejected.{% endblocktrans %}
+        {% endfilter %}
+        <br/>
+        {% filter force_escape %}
+          {% blocktrans %} Reason: {{ reason }}{% endblocktrans %}
+        {% endfilter %}
+        <br>
+        {% filter force_escape %}
+          {% blocktrans %}Please apply again to get your ID verified.{% endblocktrans %}
+        {% endfilter %}
+      </p>
+
+      <p>
+        {% trans "Enjoy your studies," as tmsg %}{{ tmsg | force_escape }}
+        <br/>
+        {% filter force_escape %}
+          {% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}
+        {% endfilter %}
+      </p>
+
+    </td>
+  </tr>
+</table>
+{% endblock %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/body.txt
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/body.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Hello {{full_name}}, {% endblocktrans %}
+{% blocktrans %}Your {{ platform_name }} ID verification photos have been rejected.{% endblocktrans %}
+{% blocktrans %}Reason: {{ reason }}{% endblocktrans %}
+{% blocktrans %}Please apply again to get your ID verified.{% endblocktrans %}
+
+{% trans "Enjoy your studies," %}
+{% blocktrans %}The {{ platform_name }} Team {% endblocktrans %}
+{% endautoescape %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/from_name.txt
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/from_name.txt
@@ -1,0 +1,1 @@
+{{ platform_name }}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/head.html
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/head.html
@@ -1,0 +1,1 @@
+{% extends 'ace_common/edx_ace/common/base_head.html' %}

--- a/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/subject.txt
+++ b/custom_student_verification/templates/custom_student_verification/edx_ace/verificationrejected/email/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Your {{ platform_name }} ID verification was rejected!{% endblocktrans %}
+{% endautoescape %}

--- a/custom_student_verification/utils.py
+++ b/custom_student_verification/utils.py
@@ -1,0 +1,62 @@
+"""
+Utility functions for custom_student_verfication app.
+"""
+import logging
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from edx_ace import ace
+from edx_ace.recipient import Recipient
+
+from custom_student_verification.compat import get_base_template_context, get_language_key, get_user_preference_model
+from custom_student_verification.message_types import VerificationApproved, VerificationRejected
+
+LANGUAGE_KEY = get_language_key()
+
+
+log = logging.getLogger(__name__)
+UserPeference = get_user_preference_model()
+
+
+def _send_verification_email(message_type, context):
+    """
+    Send and email the user through edx_ace using message_type.
+    """
+    site = Site.objects.get_current()
+    message_context = get_base_template_context(site)
+    message_context.update(context)
+    user = context['user']
+    try:
+        msg = message_type(context=message_context).personalize(
+            recipient=Recipient(user.id, user.email),
+            language=UserPeference.get_value(user, LANGUAGE_KEY, default=settings.LANGUAGE_CODE),
+            user_context={'full_name': user.profile.name}
+        )
+        ace.send(msg)
+        log.info('%s message sent to user: %r', message_type.__name__, user.username)
+        return True
+    except Exception:  # pylint: disable=broad-except
+        log.exception('Could not send message of type %s to user %s', message_type.__name__, user.username)
+        return False
+
+
+def send_verification_rejected_email(user, reason):
+    """
+    Send email to learner about ID verification rejection.
+    """
+    email_context = {
+        'user': user,
+        'reason': reason
+    }
+    return _send_verification_email(VerificationRejected, email_context)
+
+
+def send_verification_approved_email(user, reason):
+    """
+    Send email to learner about ID verification approval.
+    """
+    email_context = {
+        'user': user,
+        'reason': reason
+    }
+    return _send_verification_email(VerificationApproved, email_context)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,3 +4,4 @@
 Django
 djangorestframework
 xblock-utils
+edx-ace<1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,22 +5,32 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via fs
-django==2.2               # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework
+attrs==21.2.0             # via edx-ace
+certifi==2021.5.30        # via requests
+chardet==4.0.0            # via requests
+django==2.2               # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework, edx-ace
 djangorestframework==3.12.4  # via -r requirements/base.in
+edx-ace==0.1.17           # via -r requirements/base.in
 fs==2.4.13                # via xblock
+idna==2.10                # via requests
 lxml==4.6.3               # via xblock
 mako==1.1.4               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
-python-dateutil==2.8.1    # via xblock
+pbr==5.6.0                # via stevedore
+python-dateutil==2.8.1    # via edx-ace, xblock
 pytz==2021.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
-simplejson==3.17.2        # via xblock-utils
-six==1.16.0               # via fs, python-dateutil
+requests==2.25.1          # via sailthru-client
+sailthru-client==2.2.3    # via edx-ace
+simplejson==3.17.2        # via sailthru-client, xblock-utils
+six==1.16.0               # via edx-ace, fs, python-dateutil, stevedore
 sqlparse==0.4.1           # via django
+stevedore==1.32.0         # via edx-ace
 typing==3.7.4.3           # via fs
+urllib3==1.26.5           # via requests
 web-fragments==1.0.0      # via xblock, xblock-utils
 webob==1.8.7              # via xblock
-xblock-utils==2.1.2       # via -r requirements/base.in
+xblock-utils==2.1.3       # via -r requirements/base.in
 xblock==1.4.2             # via xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,22 +6,22 @@
 #
 appdirs==1.4.4            # via fs
 django==2.2               # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework
-djangorestframework==3.11.1  # via -r requirements/base.in
-fs==2.4.11                # via xblock
-lxml==4.5.2               # via xblock
-mako==1.1.3               # via xblock-utils
+djangorestframework==3.12.4  # via -r requirements/base.in
+fs==2.4.13                # via xblock
+lxml==4.6.3               # via xblock
+mako==1.1.4               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
 python-dateutil==2.8.1    # via xblock
-pytz==2020.1              # via django, fs, xblock
+pytz==2021.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
 simplejson==3.17.2        # via xblock-utils
-six==1.15.0               # via fs, python-dateutil, xblock
-sqlparse==0.3.1           # via django
+six==1.16.0               # via fs, python-dateutil
+sqlparse==0.4.1           # via django
 typing==3.7.4.3           # via fs
-web-fragments==0.3.2      # via xblock, xblock-utils
-webob==1.8.6              # via xblock
-xblock-utils==2.1.1       # via -r requirements/base.in
-xblock==1.4.0             # via xblock-utils
+web-fragments==1.0.0      # via xblock, xblock-utils
+webob==1.8.7              # via xblock
+xblock-utils==2.1.2       # via -r requirements/base.in
+xblock==1.4.2             # via xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,87 +5,87 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/quality.txt, -r requirements/travis.txt, fs, virtualenv
-argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/quality.txt, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, caniusepython3
-caniusepython3==7.2.0     # via -r requirements/quality.txt
-certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+attrs==21.2.0             # via -r requirements/quality.txt, edx-ace, pytest
+backports.functools-lru-cache==1.6.4  # via -r requirements/quality.txt, caniusepython3
+caniusepython3==7.3.0     # via -r requirements/quality.txt
+certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.7.0   # via -r requirements/quality.txt
-codecov==2.1.9            # via -r requirements/travis.txt
-coverage==5.3             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
-ddt==1.4.1                # via -r requirements/quality.txt
-diff-cover==4.0.0         # via -r requirements/dev.in
+code-annotations==0.10.2  # via -r requirements/quality.txt
+codecov==2.1.11           # via -r requirements/travis.txt
+coverage[toml]==5.5       # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+ddt==1.4.2                # via -r requirements/quality.txt
+diff-cover==4.2.3         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
-django==2.2               # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, djangorestframework, edx-i18n-tools
-djangorestframework==3.11.1  # via -r requirements/quality.txt
+django==2.2               # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, djangorestframework, edx-ace, edx-i18n-tools
+djangorestframework==3.12.4  # via -r requirements/quality.txt
+edx-ace==0.1.17           # via -r requirements/quality.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-fs==2.4.11                # via -r requirements/quality.txt, xblock
-httpretty==1.0.2          # via -r requirements/quality.txt
+fs==2.4.13                # via -r requirements/quality.txt, xblock
+httpretty==1.1.3          # via -r requirements/quality.txt
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
-inflect==3.0.2            # via jinja2-pluralize
-iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
+importlib-metadata==2.1.1  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==3.2.1  # via -r requirements/travis.txt, virtualenv
+inflect==3.0.2            # via diff-cover, jinja2-pluralize
+iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
+jinja2==2.11.3            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
-lxml==4.5.2               # via -r requirements/quality.txt, xblock
-mako==1.1.3               # via -r requirements/quality.txt, xblock-utils
+lxml==4.6.3               # via -r requirements/quality.txt, xblock
+mako==1.1.4               # via -r requirements/quality.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2, mako, xblock
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -r requirements/quality.txt
-more-itertools==8.5.0     # via -r requirements/quality.txt, pytest
-packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, pytest, tox
+packaging==20.9           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pbr==5.5.0                # via -r requirements/quality.txt, stevedore
+pbr==5.6.0                # via -r requirements/quality.txt, stevedore
 pillow==7.2.0             # via -r requirements/quality.txt
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
-polib==1.1.0              # via edx-i18n-tools
-py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pycodestyle==2.6.0        # via -r requirements/quality.txt
+polib==1.1.1              # via edx-i18n-tools
+py==1.10.0                # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pycodestyle==2.7.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.1           # via diff-cover
+pygments==2.9.0           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
-pylint-django==2.0.11 ; python_version >= "3.0"  # via -r requirements/quality.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.4 ; python_version >= "3.0"  # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
-pytest-cov==2.10.1        # via -r requirements/quality.txt
-pytest-django==3.10.0     # via -r requirements/quality.txt
-pytest==6.0.2             # via -r requirements/quality.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt, xblock
+pytest-cov==2.12.0        # via -r requirements/quality.txt
+pytest-django==4.3.0      # via -r requirements/quality.txt
+pytest==6.1.2             # via -r requirements/quality.txt, pytest-cov, pytest-django
+python-dateutil==2.8.1    # via -r requirements/quality.txt, edx-ace, xblock
 python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
-pytz==2020.1              # via -r requirements/quality.txt, django, fs, xblock
+pytz==2021.1              # via -r requirements/quality.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools, xblock
-requests==2.24.0          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov
-simplejson==3.17.2        # via -r requirements/quality.txt, xblock-utils
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, fs, mock, packaging, pathlib2, pip-tools, python-dateutil, stevedore, tox, virtualenv, xblock
-snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
-sqlparse==0.3.1           # via -r requirements/quality.txt, django
-stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations
+requests==2.25.1          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov, sailthru-client
+sailthru-client==2.2.3    # via -r requirements/quality.txt, edx-ace
+simplejson==3.17.2        # via -r requirements/quality.txt, sailthru-client, xblock-utils
+six==1.16.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-ace, edx-i18n-tools, edx-lint, fs, mock, pathlib2, pip-tools, python-dateutil, stevedore, tox, virtualenv
+snowballstemmer==2.1.0    # via -r requirements/quality.txt, pydocstyle
+sqlparse==0.4.1           # via -r requirements/quality.txt, django
+stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-ace
 text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
-toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, coverage, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
-typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
+tox==3.23.1               # via -r requirements/travis.txt, tox-battery
+typed-ast==1.4.3          # via -r requirements/quality.txt, astroid
 typing==3.7.4.3           # via -r requirements/quality.txt, fs
-urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-virtualenv==20.0.31       # via -r requirements/travis.txt, tox
-web-fragments==0.3.2      # via -r requirements/quality.txt, xblock, xblock-utils
-webob==1.8.6              # via -r requirements/quality.txt, xblock
+urllib3==1.26.4           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.4.7        # via -r requirements/travis.txt, tox
+web-fragments==1.0.0      # via -r requirements/quality.txt, xblock, xblock-utils
+webob==1.8.7              # via -r requirements/quality.txt, xblock
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-xblock-utils==2.1.1       # via -r requirements/quality.txt
-xblock==1.4.0             # via -r requirements/quality.txt, xblock-utils
+xblock-utils==2.1.2       # via -r requirements/quality.txt
+xblock==1.4.2             # via -r requirements/quality.txt, xblock-utils
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-cele
 attrs==21.2.0             # via -r requirements/quality.txt, edx-ace, pytest
 backports.functools-lru-cache==1.6.4  # via -r requirements/quality.txt, caniusepython3
 caniusepython3==7.3.0     # via -r requirements/quality.txt
-certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+certifi==2021.5.30        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
@@ -18,7 +18,7 @@ codecov==2.1.11           # via -r requirements/travis.txt
 coverage[toml]==5.5       # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.2                # via -r requirements/quality.txt
 diff-cover==4.2.3         # via -r requirements/dev.in
-distlib==0.3.1            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
+distlib==0.3.2            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
 django==2.2               # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, djangorestframework, edx-ace, edx-i18n-tools
 djangorestframework==3.12.4  # via -r requirements/quality.txt
 edx-ace==0.1.17           # via -r requirements/quality.txt
@@ -79,12 +79,12 @@ tox-battery==0.6.1        # via -r requirements/travis.txt
 tox==3.23.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.3          # via -r requirements/quality.txt, astroid
 typing==3.7.4.3           # via -r requirements/quality.txt, fs
-urllib3==1.26.4           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+urllib3==1.26.5           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 virtualenv==20.4.7        # via -r requirements/travis.txt, tox
 web-fragments==1.0.0      # via -r requirements/quality.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/quality.txt, xblock
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-xblock-utils==2.1.2       # via -r requirements/quality.txt
+xblock-utils==2.1.3       # via -r requirements/quality.txt
 xblock==1.4.2             # via -r requirements/quality.txt, xblock-utils
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,4 +1,4 @@
 # Just the dependencies to run pip-tools, mainly for the "upgrade" make target
 -c constraints.txt
 
-pip-tools                 # Contains pip-compile, used to generate pip requirements files
+pip-tools==5.3.1          # Contains pip-compile, used to generate pip requirements files

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.2              # via pip-tools
 pip-tools==5.3.1          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+six==1.16.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -4,11 +4,7 @@
 -r test.txt               # Core and testing dependencies for this package
 
 caniusepython3            # Additional Python 3 compatibility pylint checks
-edx-lint                  # edX pylint rules and plugins
+edx-lint==1.5.2               # edX pylint rules and plugins. Pinning for py35 support
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
-pylint==1.9.5;python_version<"3.0"  # The last pylint version to support python 2
-pylint==2.4.4;python_version>="3.0"
-pylint-django==0.11.1;python_version<"3.0"  # The last pylint-django to support python 2
-pylint-django==2.0.11;python_version>="3.0"

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,14 +9,14 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==21.2.0             # via -r requirements/test.txt, edx-ace, pytest
 backports.functools-lru-cache==1.6.4  # via caniusepython3
 caniusepython3==7.3.0     # via -r requirements/quality.in
-certifi==2020.12.5        # via -r requirements/test.txt, requests
+certifi==2021.5.30        # via -r requirements/test.txt, requests
 chardet==4.0.0            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.txt
 coverage[toml]==5.5       # via -r requirements/test.txt, pytest-cov
 ddt==1.4.2                # via -r requirements/test.txt
-distlib==0.3.1            # via caniusepython3
+distlib==0.3.2            # via caniusepython3
 django==2.2               # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, djangorestframework, edx-ace
 djangorestframework==3.12.4  # via -r requirements/test.txt
 edx-ace==0.1.17           # via -r requirements/test.txt
@@ -65,11 +65,11 @@ text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, coverage, pytest
 typed-ast==1.4.3          # via astroid
 typing==3.7.4.3           # via -r requirements/test.txt, fs
-urllib3==1.26.4           # via -r requirements/test.txt, requests
+urllib3==1.26.5           # via -r requirements/test.txt, requests
 web-fragments==1.0.0      # via -r requirements/test.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/test.txt, xblock
 wrapt==1.11.2             # via astroid
-xblock-utils==2.1.2       # via -r requirements/test.txt
+xblock-utils==2.1.3       # via -r requirements/test.txt
 xblock==1.4.2             # via -r requirements/test.txt, xblock-utils
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,72 +5,72 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/test.txt, fs
-argparse==1.4.0           # via caniusepython3
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/test.txt, pytest
-backports.functools-lru-cache==1.6.1  # via caniusepython3
-caniusepython3==7.2.0     # via -r requirements/quality.in
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
+attrs==21.2.0             # via -r requirements/test.txt, edx-ace, pytest
+backports.functools-lru-cache==1.6.4  # via caniusepython3
+caniusepython3==7.3.0     # via -r requirements/quality.in
+certifi==2020.12.5        # via -r requirements/test.txt, requests
+chardet==4.0.0            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.7.0   # via -r requirements/test.txt
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-ddt==1.4.1                # via -r requirements/test.txt
+code-annotations==0.10.2  # via -r requirements/test.txt
+coverage[toml]==5.5       # via -r requirements/test.txt, pytest-cov
+ddt==1.4.2                # via -r requirements/test.txt
 distlib==0.3.1            # via caniusepython3
-django==2.2               # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, djangorestframework
-djangorestframework==3.11.1  # via -r requirements/test.txt
+django==2.2               # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, djangorestframework, edx-ace
+djangorestframework==3.12.4  # via -r requirements/test.txt
+edx-ace==0.1.17           # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/quality.in
-fs==2.4.11                # via -r requirements/test.txt, xblock
-httpretty==1.0.2          # via -r requirements/test.txt
-idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
+fs==2.4.13                # via -r requirements/test.txt, xblock
+httpretty==1.1.3          # via -r requirements/test.txt
+idna==2.10                # via -r requirements/test.txt, requests
+importlib-metadata==2.1.1  # via -r requirements/test.txt, pluggy, pytest
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
-jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
+jinja2==2.11.3            # via -r requirements/test.txt, code-annotations
 lazy-object-proxy==1.4.3  # via astroid
-lxml==4.5.2               # via -r requirements/test.txt, xblock
-mako==1.1.3               # via -r requirements/test.txt, xblock-utils
+lxml==4.6.3               # via -r requirements/test.txt, xblock
+mako==1.1.4               # via -r requirements/test.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==8.5.0     # via -r requirements/test.txt, pytest
-packaging==20.4           # via -r requirements/test.txt, caniusepython3, pytest
+packaging==20.9           # via -r requirements/test.txt, caniusepython3, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.5.0                # via -r requirements/test.txt, stevedore
+pbr==5.6.0                # via -r requirements/test.txt, stevedore
 pillow==7.2.0             # via -r requirements/test.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.9.0                 # via -r requirements/test.txt, pytest
-pycodestyle==2.6.0        # via -r requirements/quality.in, -r requirements/test.txt
+py==1.10.0                # via -r requirements/test.txt, pytest
+pycodestyle==2.7.0        # via -r requirements/quality.in, -r requirements/test.txt
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11 ; python_version >= "3.0"  # via -r requirements/quality.in, edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4 ; python_version >= "3.0"  # via -r requirements/quality.in, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/test.txt
-pytest==6.0.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt, xblock
+pytest-cov==2.12.0        # via -r requirements/test.txt
+pytest-django==4.3.0      # via -r requirements/test.txt
+pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+python-dateutil==2.8.1    # via -r requirements/test.txt, edx-ace, xblock
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
-pytz==2020.1              # via -r requirements/test.txt, django, fs, xblock
+pytz==2021.1              # via -r requirements/test.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, xblock
-requests==2.24.0          # via caniusepython3
-simplejson==3.17.2        # via -r requirements/test.txt, xblock-utils
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, fs, mock, packaging, pathlib2, python-dateutil, stevedore, xblock
-snowballstemmer==2.0.0    # via pydocstyle
-sqlparse==0.3.1           # via -r requirements/test.txt, django
-stevedore==1.32.0         # via -r requirements/test.txt, code-annotations
+requests==2.25.1          # via -r requirements/test.txt, caniusepython3, sailthru-client
+sailthru-client==2.2.3    # via -r requirements/test.txt, edx-ace
+simplejson==3.17.2        # via -r requirements/test.txt, sailthru-client, xblock-utils
+six==1.16.0               # via -r requirements/test.txt, astroid, edx-ace, edx-lint, fs, mock, pathlib2, python-dateutil, stevedore
+snowballstemmer==2.1.0    # via pydocstyle
+sqlparse==0.4.1           # via -r requirements/test.txt, django
+stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-ace
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, pytest
-typed-ast==1.4.1          # via astroid
+toml==0.10.2              # via -r requirements/test.txt, coverage, pytest
+typed-ast==1.4.3          # via astroid
 typing==3.7.4.3           # via -r requirements/test.txt, fs
-urllib3==1.25.10          # via requests
-web-fragments==0.3.2      # via -r requirements/test.txt, xblock, xblock-utils
-webob==1.8.6              # via -r requirements/test.txt, xblock
+urllib3==1.26.4           # via -r requirements/test.txt, requests
+web-fragments==1.0.0      # via -r requirements/test.txt, xblock, xblock-utils
+webob==1.8.7              # via -r requirements/test.txt, xblock
 wrapt==1.11.2             # via astroid
-xblock-utils==2.1.1       # via -r requirements/test.txt
-xblock==1.4.0             # via -r requirements/test.txt, xblock-utils
+xblock-utils==2.1.2       # via -r requirements/test.txt
+xblock==1.4.2             # via -r requirements/test.txt, xblock-utils
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,10 +5,10 @@
 
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
-code-annotations          # provides commands used by the pii_check make target.
+code-annotations<1        # provides commands used by the pii_check make target. Pinned <1 for py35 support.
 mock
 ddt
 httpretty
 Pillow
 pycodestyle
-edx-ace
+edx-ace<1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,4 +11,3 @@ ddt
 httpretty
 Pillow
 pycodestyle
-edx-ace<1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,3 +11,4 @@ ddt
 httpretty
 Pillow
 pycodestyle
+edx-ace

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,49 +5,54 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/base.txt, fs
-attrs==20.2.0             # via pytest
+attrs==21.2.0             # via edx-ace, pytest
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
 click==7.1.2              # via code-annotations
-code-annotations==0.7.0   # via -r requirements/test.in
-coverage==5.3             # via pytest-cov
-ddt==1.4.1                # via -r requirements/test.in
-djangorestframework==3.11.1  # via -r requirements/base.txt
-edx-ace==1.1.0            # via -r requirements/test.in
-fs==2.4.11                # via -r requirements/base.txt, xblock
-httpretty==1.0.2          # via -r requirements/test.in
-importlib-metadata==1.7.0  # via pluggy, pytest
-iniconfig==1.0.1          # via pytest
-jinja2==2.11.2            # via code-annotations
-lxml==4.5.2               # via -r requirements/base.txt, xblock
-mako==1.1.3               # via -r requirements/base.txt, xblock-utils
+code-annotations==0.10.2  # via -r requirements/test.in
+coverage[toml]==5.5       # via pytest-cov
+ddt==1.4.2                # via -r requirements/test.in
+djangorestframework==3.12.4  # via -r requirements/base.txt
+edx-ace==0.1.17           # via -r requirements/test.in
+fs==2.4.13                # via -r requirements/base.txt, xblock
+httpretty==1.1.3          # via -r requirements/test.in
+idna==2.10                # via requests
+importlib-metadata==2.1.1  # via pluggy, pytest
+iniconfig==1.1.1          # via pytest
+jinja2==2.11.3            # via code-annotations
+lxml==4.6.3               # via -r requirements/base.txt, xblock
+mako==1.1.4               # via -r requirements/base.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, mako, xblock
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.5.0     # via pytest
-packaging==20.4           # via pytest
+packaging==20.9           # via pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.5.0                # via stevedore
+pbr==5.6.0                # via stevedore
 pillow==7.2.0             # via -r requirements/test.in
 pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
-pycodestyle==2.6.0        # via -r requirements/test.in
+py==1.10.0                # via pytest
+pycodestyle==2.7.0        # via -r requirements/test.in
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==3.10.0     # via -r requirements/test.in
-pytest==6.0.2             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/base.txt, xblock
+pytest-cov==2.12.0        # via -r requirements/test.in
+pytest-django==4.3.0      # via -r requirements/test.in
+pytest==6.1.2             # via pytest-cov, pytest-django
+python-dateutil==2.8.1    # via -r requirements/base.txt, edx-ace, xblock
 python-slugify==4.0.1     # via code-annotations
-pytz==2020.1              # via -r requirements/base.txt, django, fs, xblock
+pytz==2021.1              # via -r requirements/base.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, xblock
-simplejson==3.17.2        # via -r requirements/base.txt, xblock-utils
-six==1.15.0               # via -r requirements/base.txt, fs, mock, packaging, pathlib2, python-dateutil, stevedore, xblock
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via code-annotations
+requests==2.25.1          # via sailthru-client
+sailthru-client==2.2.3    # via edx-ace
+simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client, xblock-utils
+six==1.16.0               # via -r requirements/base.txt, edx-ace, fs, mock, pathlib2, python-dateutil, stevedore
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+stevedore==1.32.0         # via code-annotations, edx-ace
 text-unidecode==1.3       # via python-slugify
-toml==0.10.1              # via pytest
+toml==0.10.2              # via coverage, pytest
 typing==3.7.4.3           # via -r requirements/base.txt, fs
-web-fragments==0.3.2      # via -r requirements/base.txt, xblock, xblock-utils
-webob==1.8.6              # via -r requirements/base.txt, xblock
-xblock-utils==2.1.1       # via -r requirements/base.txt
-xblock==1.4.0             # via -r requirements/base.txt, xblock-utils
+urllib3==1.26.4           # via requests
+web-fragments==1.0.0      # via -r requirements/base.txt, xblock, xblock-utils
+webob==1.8.7              # via -r requirements/base.txt, xblock
+xblock-utils==2.1.2       # via -r requirements/base.txt
+xblock==1.4.2             # via -r requirements/base.txt, xblock-utils
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,6 +11,7 @@ code-annotations==0.7.0   # via -r requirements/test.in
 coverage==5.3             # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
 djangorestframework==3.11.1  # via -r requirements/base.txt
+edx-ace==1.1.0            # via -r requirements/test.in
 fs==2.4.11                # via -r requirements/base.txt, xblock
 httpretty==1.0.2          # via -r requirements/test.in
 importlib-metadata==1.7.0  # via pluggy, pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,18 +5,18 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/base.txt, fs
-attrs==21.2.0             # via edx-ace, pytest
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
+attrs==21.2.0             # via -r requirements/base.txt, edx-ace, pytest
+certifi==2021.5.30        # via -r requirements/base.txt, requests
+chardet==4.0.0            # via -r requirements/base.txt, requests
 click==7.1.2              # via code-annotations
 code-annotations==0.10.2  # via -r requirements/test.in
 coverage[toml]==5.5       # via pytest-cov
 ddt==1.4.2                # via -r requirements/test.in
 djangorestframework==3.12.4  # via -r requirements/base.txt
-edx-ace==0.1.17           # via -r requirements/test.in
+edx-ace==0.1.17           # via -r requirements/base.txt
 fs==2.4.13                # via -r requirements/base.txt, xblock
 httpretty==1.1.3          # via -r requirements/test.in
-idna==2.10                # via requests
+idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==2.1.1  # via pluggy, pytest
 iniconfig==1.1.1          # via pytest
 jinja2==2.11.3            # via code-annotations
@@ -26,7 +26,7 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, mako, xblock
 mock==3.0.5               # via -r requirements/test.in
 packaging==20.9           # via pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.6.0                # via stevedore
+pbr==5.6.0                # via -r requirements/base.txt, stevedore
 pillow==7.2.0             # via -r requirements/test.in
 pluggy==0.13.1            # via pytest
 py==1.10.0                # via pytest
@@ -39,19 +39,19 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, edx-ace, xblock
 python-slugify==4.0.1     # via code-annotations
 pytz==2021.1              # via -r requirements/base.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, xblock
-requests==2.25.1          # via sailthru-client
-sailthru-client==2.2.3    # via edx-ace
+requests==2.25.1          # via -r requirements/base.txt, sailthru-client
+sailthru-client==2.2.3    # via -r requirements/base.txt, edx-ace
 simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client, xblock-utils
 six==1.16.0               # via -r requirements/base.txt, edx-ace, fs, mock, pathlib2, python-dateutil, stevedore
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via code-annotations, edx-ace
+stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-ace
 text-unidecode==1.3       # via python-slugify
 toml==0.10.2              # via coverage, pytest
 typing==3.7.4.3           # via -r requirements/base.txt, fs
-urllib3==1.26.4           # via requests
+urllib3==1.26.5           # via -r requirements/base.txt, requests
 web-fragments==1.0.0      # via -r requirements/base.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/base.txt, xblock
-xblock-utils==2.1.2       # via -r requirements/base.txt
+xblock-utils==2.1.3       # via -r requirements/base.txt
 xblock==1.4.2             # via -r requirements/base.txt, xblock-utils
 zipp==1.2.0               # via importlib-metadata
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,24 +5,24 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
-coverage==5.3             # via codecov
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
+codecov==2.1.11           # via -r requirements/travis.in
+coverage==5.5             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
-packaging==20.4           # via tox
+importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
+importlib-resources==3.2.1  # via virtualenv
+packaging==20.9           # via tox
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
+py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.24.0          # via codecov
-six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
+requests==2.25.1          # via codecov
+six==1.16.0               # via tox, virtualenv
+toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.20.0               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.10          # via requests
-virtualenv==20.0.31       # via tox
+tox==3.23.1               # via -r requirements/travis.in, tox-battery
+urllib3==1.26.4           # via requests
+virtualenv==20.4.7        # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,11 +5,11 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.12.5        # via requests
+certifi==2021.5.30        # via requests
 chardet==4.0.0            # via requests
 codecov==2.1.11           # via -r requirements/travis.in
 coverage==5.5             # via codecov
-distlib==0.3.1            # via virtualenv
+distlib==0.3.2            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
 importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
@@ -23,6 +23,6 @@ six==1.16.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.23.1               # via -r requirements/travis.in, tox-battery
-urllib3==1.26.4           # via requests
+urllib3==1.26.5           # via requests
 virtualenv==20.4.7        # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/test_settings.py
+++ b/test_settings.py
@@ -31,6 +31,7 @@ DATABASES = {
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.sites',
     'custom_student_verification',
     'test_utils',
 )
@@ -43,3 +44,4 @@ ROOT_URLCONF = 'test_utils.urls'
 
 SECRET_KEY = 'insecure-secret-key'
 
+SITE_ID = 1

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -1,0 +1,41 @@
+"""
+Tests for utility functions of custom_student_verfication app.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from custom_student_verification.message_types import VerificationApproved, VerificationRejected
+from custom_student_verification.utils import send_verification_approved_email, send_verification_rejected_email
+
+
+class VerificationEmailTestCase(TestCase):
+    """
+    Tests for verification email utility functions.
+    """
+
+    def setUp(self) -> None:
+        self.user = User.objects.create(username="testuser", email="test@example.com")
+        return super().setUp()
+
+    @patch('custom_student_verification.utils._send_verification_email')
+    def test_verification_email(self, mock_sender):
+        send_verification_rejected_email(self.user, "Reason for rejection")
+        context = {
+            'user': self.user,
+            'reason': "Reason for rejection"
+        }
+        mock_sender.assert_called_with(VerificationRejected, context)
+
+    @patch('custom_student_verification.utils._send_verification_email')
+    def test_verification_rejected_email(self, mock_sender):
+        """
+        """
+        send_verification_approved_email(self.user, "Reason for approval")
+        context = {
+            'user': self.user,
+            'reason': "Reason for approval"
+        }
+        mock_sender.assert_called_with(VerificationApproved, context)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,54 @@
+"""
+Tests for signal receivers of custom_verification_app.
+"""
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from custom_student_verification.models import StudentVerificationRequest
+
+
+class VerificationSignalTestCase(TestCase):
+    """
+    Tests for signal receivers of custom_verification_app.
+    """
+
+    def setUp(self) -> None:
+        self.user = User.objects.create(username="testuser", email="test@example.clm")
+        self.user.profile = MagicMock()
+        self.user.profile.name.return_value = "Test User"
+        self.verification_request = StudentVerificationRequest.objects.create(
+            user=self.user,
+            status="PENDING"
+        )
+        return super().setUp()
+
+    @patch('custom_student_verification.signals.get_manual_verification_model')
+    @patch('custom_student_verification.signals.send_verification_rejected_email')
+    def test_rejection_email_is_sent(self, mock_email, mock_model_method):
+        """
+        Tests that the email is sent when verification is rejected.
+        """
+        mock_manual_verification_model = MagicMock()
+        mock_model_method.return_value = mock_manual_verification_model
+
+        self.verification_request.status = "REJECTED"
+        self.verification_request.reason = "Reason for rejection"
+        self.verification_request.save()
+        mock_email.assert_called_with(self.user, "Reason for rejection")
+
+    @patch('custom_student_verification.signals.get_manual_verification_model')
+    @patch('custom_student_verification.signals.send_verification_approved_email')
+    def test_approval_email_is_sent(self, mock_email, mock_model_method):
+        """
+        Test that the email is sent when verification request is approved.
+        """
+        mock_manual_verification_model = MagicMock()
+        mock_model_method.return_value = mock_manual_verification_model
+        mock_manual_verification_model.objects.filter().exists.return_value = False
+
+        self.verification_request.status = "ACCEPTED"
+        self.verification_request.reason = "Reason for accepting"
+        self.verification_request.save()
+        mock_email.assert_called_with(self.user, "Reason for accepting")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -57,11 +57,14 @@ class CustomStudentVerificationGetTest(TestCase):
         self.assertRegex(html, r'<form .*>')
         [self.assertNotIn(keyword, html) for keyword in ['accepted', 'rejected', 'processed']]
 
-    def test_previously_rejected(self):
+    @patch('custom_student_verification.signals.reject_user')
+    def test_previously_rejected(self, mock_method):
         StudentVerificationRequest.objects.create(
             user=self.student,
             status='REJECTED'
         )
+
+        mock_method.assert_called_once_with(self.student, None)
 
         request = self.factory.get(
             reverse('custom_student_verification_app:custom-student-verification')
@@ -267,11 +270,14 @@ class CustomStudentVerificationPostTest(TestCase):
         self.assertIn('processed', html)
         [self.assertNotIn(keyword, html) for keyword in ['accepted', 'rejected']]
 
-    def test_previously_rejected(self):
+    @patch('custom_student_verification.signals.reject_user')
+    def test_previously_rejected(self, mock_method):
         StudentVerificationRequest.objects.create(
             user=self.student,
             status="REJECTED"
         )
+
+        mock_method.assert_called_once_with(self.student, None)
 
         request = self.factory.post(
             reverse('custom_student_verification_app:custom-student-verification')


### PR DESCRIPTION
Uses edx-ace to send emails on student verification application
rejection and approval.

Related Tickets: [BB-4221]()

#### Testing Instructions

1. On a `juniper` devstack, clone this under `{devstack_folder}/src` (devstack_folder is the one that contains edx-platform, devstack, and the other folders.
1. Get into the LMS shell using `make lms-shell`.
1. Install the app using pip: `pip install -e /edx/src/custom-student-verification`
2. Restart LMS
3. Log into LMS with an unverified user and visit http://localhost:18000/custom-student-verification
4. Upload an image and submit
5. With a staff user logged in visit http://localhost:18000/admin/custom_student_verification/studentverificationrequest/
6. Open the verification request created above, mark it `approved` and save.
7. Verify that an email is sent by checking the latest file in `/edx/src/ace_messages` in `lms-shell`
8. Open the verification request created above again in your browser.
9. Mark the request `rejected` and save.
10. Verify that a rejected email is send by checking the file in `/edx/src/ace_messages`.
11. The above emails can also be seen in `lms-logs`

#### Author Notes
1. The email will be sent every time the verification request is marked `rejected`. This includes just opening a `rejected` request and saving it again from browser.
2. When the request is marked `rejected`, the `approved` records from `ManualVerification` are deleted.
3. The requirements are updated since `edx_ace` is added.