### PR TITLE
chore: Add *txt to included files in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
 include requirements/base.in
-recursive-include custom_student_verification *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
+recursive-include custom_student_verification *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *txt

--- a/custom_student_verification/__init__.py
+++ b/custom_student_verification/__init__.py
@@ -4,6 +4,6 @@ Custom Django app for student verification.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 default_app_config = 'custom_student_verification.apps.CustomStudentVerificationConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updates MANIFEST.in to include txt files

**Testing Instructions**
1. Checkout to this branch.
2. Generate distribution archive using `build` tool. See [this documentation](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives)
3. The archives will be generated in `dist` folder.
4. Check that the archive contains `txt` files.
