### PR TITLE
BB-4474: Fix admin page when images are not present 

### DIFF
--- a/custom_student_verification/__init__.py
+++ b/custom_student_verification/__init__.py
@@ -4,6 +4,6 @@ Custom Django app for student verification.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 
 default_app_config = 'custom_student_verification.apps.CustomStudentVerificationConfig'  # pylint: disable=invalid-name

--- a/custom_student_verification/models.py
+++ b/custom_student_verification/models.py
@@ -30,4 +30,5 @@ class StudentVerificationRequest(models.Model):
         """
         Return <img> tag with SRC set as the photo ID provided by the student.
         """
-        return mark_safe('<img src="%s" style="max-height:15rem;" />' % self.id_photo.url)
+        if self.id_photo:
+            return mark_safe('<img src="%s" style="max-height:15rem;" />' % self.id_photo.url)

--- a/custom_student_verification/models.py
+++ b/custom_student_verification/models.py
@@ -32,3 +32,4 @@ class StudentVerificationRequest(models.Model):
         """
         if self.id_photo:
             return mark_safe('<img src="%s" style="max-height:15rem;" />' % self.id_photo.url)
+        return ""


### PR DESCRIPTION
Fixes a bug that made the admin page break when working with users without images (e.g. when importing verifications without ID picture).

Fixes https://github.com/open-craft/custom-student-verification/issues/6.

**Testing instructions:**
1. Install this in a Koa devstack.
2. Open django shell (`make lms-shell`, `./manage.py lms shell`).
3. Add a verification without image:
```
from custom_student_verification.models import StudentVerificationRequest
StudentVerificationRequest.objects.create(user_id=1)
```
4. Check that the Django admin page works: http://localhost:18000/admin/custom_student_verification/studentverificationrequest/
5. Optionally test with the current master to see the issue.

**Reviewers:**
- [x] @shimulch 
- [ ] @lgp171188 
