### PR TITLE
test: Simplify CI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,17 @@
 version: 2.1
+
 commands:
   requirements:
-    parameters:
-      python_version:
-        type: "string"
-        default: "3.5"
     steps:
       - run:
-          name: Install virtualenv
-          command: sudo apt-get update && sudo apt-get -y -q install virtualenv
-      - run:
           name: Create a virtualenv environment
-          command: "virtualenv -p python<<parameters.python_version>> venv"
+          command: "virtualenv venv"
 
       - run:
           name: Install requirements
           command: ". venv/bin/activate && make requirements"
 
 jobs:
-  python35-quality:
-    docker:
-      - image: circleci/python:3.5
-    steps:
-      - checkout
-      - restore_cache:
-          keys: python3.5
-      - requirements
-      - run:
-          name: Run the code quality checks
-          command: "./venv/bin/tox -e quality"
-      - save_cache:
-          key: python3.5
-          paths:
-            - .tox
-            - /home/circleci/.cache/pip
-
   python38-quality:
     docker:
       - image: circleci/python:3.8
@@ -42,32 +19,15 @@ jobs:
       - checkout
       - restore_cache:
           keys: python3.8
-      - requirements:
-          python_version: "3.8"
+      - requirements
       - run:
-          name: Run the code quality checks
-          command: "./venv/bin/tox -e quality"
+          name: Run code quality checks
+          command: . venv/bin/activate && tox -e quality
       - save_cache:
           key: python3.8
           paths:
             - .tox
-            - /home/circleci/.cache/pip
-
-  python35:
-    docker:
-      - image: circleci/python:3.5
-    steps:
-      - checkout
-      - restore_cache:
-          keys: python3.5
-      - requirements
-      - run:
-          name: Run the tests using Python 3.5
-          command: './venv/bin/tox -e "py{35}-django{22}"'
-      - save_cache:
-          key: python3.5
-          paths:
-            - .tox
+            - venv
             - /home/circleci/.cache/pip
 
   python38:
@@ -77,43 +37,39 @@ jobs:
       - checkout
       - restore_cache:
           keys: python3.8
-      - requirements:
-          python_version: "3.8"
+      - requirements
       - run:
-          name: Run the tests using Python 3.8
-          command: './venv/bin/tox -e "py{38}-django{22}"'
+          name: Run tests using Python 3.8
+          command: . venv/bin/activate && tox -e "py{38}-django{22}"
       - save_cache:
           key: python3.8
           paths:
             - .tox
+            - venv
             - /home/circleci/.cache/pip
+
   pii_check:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.8
     steps:
       - checkout
       - restore_cache:
-          keys: python3.5
+          keys: python3.8
       - requirements
       - run:
-          name: Run the PII checks
-          command: "./venv/bin/tox -e pii_check"
+          name: Run PII checks
+          command: . venv/bin/activate && tox -e pii_check
       - save_cache:
-          key: python3.5
+          key: python3.8
           paths:
             - .tox
+            - venv
             - /home/circleci/.cache/pip
 
 workflows:
   version: 2
   main:
     jobs:
-      - python35-quality
       - python38-quality
-      - python35:
-          requires:
-            - python35-quality
-      - python38:
-          requires:
-            - python38-quality
+      - python38
       - pii_check


### PR DESCRIPTION
This PR simplifies the CI checks and removes CI checks for Python 3.5 (Juniper release and earlier).


**Reviewer:**
- [ ] @xitij2000 (as FF) OR 
- [ ] @alfredchavez (working on a related task in the sprint) OR
- [x] @Agrendalath (since you commented about the CI :stuck_out_tongue:)