### PR TITLE
[SE-5409] Update edx-ace version and run make upgrade

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,4 +4,4 @@
 Django
 djangorestframework
 xblock-utils
-edx-ace<1
+edx-ace==1.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,33 +5,33 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via fs
-attrs==21.2.0             # via edx-ace
-certifi==2021.5.30        # via requests
+attrs==21.4.0             # via edx-ace
+certifi==2021.10.8        # via requests
 chardet==4.0.0            # via requests
 django==2.2               # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework, edx-ace
 djangorestframework==3.12.4  # via -r requirements/base.in
-edx-ace==0.1.17           # via -r requirements/base.in
-fs==2.4.13                # via xblock
+edx-ace==1.1.0            # via -r requirements/base.in
+fs==2.4.15                # via xblock
 idna==2.10                # via requests
-lxml==4.6.3               # via xblock
-mako==1.1.4               # via xblock-utils
+lxml==4.8.0               # via xblock
+mako==1.1.6               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
-pbr==5.6.0                # via stevedore
-python-dateutil==2.8.1    # via edx-ace, xblock
-pytz==2021.1              # via django, fs, xblock
+pbr==5.8.1                # via stevedore
+python-dateutil==2.8.2    # via edx-ace, xblock
+pytz==2021.3              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
 requests==2.25.1          # via sailthru-client
 sailthru-client==2.2.3    # via edx-ace
-simplejson==3.17.2        # via sailthru-client, xblock-utils
+simplejson==3.17.6        # via sailthru-client, xblock-utils
 six==1.16.0               # via edx-ace, fs, python-dateutil, stevedore
-sqlparse==0.4.1           # via django
+sqlparse==0.4.2           # via django
 stevedore==1.32.0         # via edx-ace
 typing==3.7.4.3           # via fs
-urllib3==1.26.5           # via requests
-web-fragments==1.0.0      # via xblock, xblock-utils
+urllib3==1.26.8           # via requests
+web-fragments==2.0.0      # via xblock, xblock-utils
 webob==1.8.7              # via xblock
-xblock-utils==2.1.3       # via -r requirements/base.in
-xblock==1.4.2             # via xblock-utils
+xblock-utils==3.0.0       # via -r requirements/base.in
+xblock==1.6.1             # via xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,31 +4,31 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via -r requirements/quality.txt, -r requirements/travis.txt, fs, virtualenv
+appdirs==1.4.4            # via -r requirements/quality.txt, fs
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
-attrs==21.2.0             # via -r requirements/quality.txt, edx-ace, pytest
+attrs==21.4.0             # via -r requirements/quality.txt, edx-ace, pytest
 backports.functools-lru-cache==1.6.4  # via -r requirements/quality.txt, caniusepython3
 caniusepython3==7.3.0     # via -r requirements/quality.txt
-certifi==2021.5.30        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+certifi==2021.10.8        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.10.2  # via -r requirements/quality.txt
-codecov==2.1.11           # via -r requirements/travis.txt
-coverage[toml]==5.5       # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
-ddt==1.4.2                # via -r requirements/quality.txt
+codecov==2.1.12           # via -r requirements/travis.txt
+coverage==5.5             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+ddt==1.4.4                # via -r requirements/quality.txt
 diff-cover==4.2.3         # via -r requirements/dev.in
-distlib==0.3.2            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
+distlib==0.3.4            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
 django==2.2               # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, djangorestframework, edx-ace, edx-i18n-tools
 djangorestframework==3.12.4  # via -r requirements/quality.txt
-edx-ace==0.1.17           # via -r requirements/quality.txt
-edx-i18n-tools==0.5.3     # via -r requirements/dev.in
+edx-ace==1.1.0            # via -r requirements/quality.txt
+edx-i18n-tools==0.9.1     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/quality.txt
-filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-fs==2.4.13                # via -r requirements/quality.txt, xblock
-httpretty==1.1.3          # via -r requirements/quality.txt
+filelock==3.2.1           # via -r requirements/travis.txt, tox, virtualenv
+fs==2.4.15                # via -r requirements/quality.txt, xblock
+httpretty==1.1.4          # via -r requirements/quality.txt
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.1.3  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.2.1  # via -r requirements/travis.txt, virtualenv
 inflect==3.0.2            # via diff-cover, jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
@@ -36,56 +36,56 @@ isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.3            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
-lxml==4.6.3               # via -r requirements/quality.txt, xblock
-mako==1.1.4               # via -r requirements/quality.txt, xblock-utils
+lxml==4.8.0               # via -r requirements/quality.txt, xblock
+mako==1.1.6               # via -r requirements/quality.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2, mako, xblock
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -r requirements/quality.txt
 packaging==20.9           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, pytest, tox
-path.py==12.5.0           # via edx-i18n-tools
-path==13.1.0              # via path.py
-pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pbr==5.6.0                # via -r requirements/quality.txt, stevedore
+path==13.1.0              # via edx-i18n-tools
+pathlib2==2.3.7.post1     # via -r requirements/quality.txt, pytest
+pbr==5.8.1                # via -r requirements/quality.txt, stevedore
 pillow==7.2.0             # via -r requirements/quality.txt
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
+platformdirs==2.0.2       # via -r requirements/travis.txt, virtualenv
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.1              # via edx-i18n-tools
-py==1.10.0                # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pycodestyle==2.7.0        # via -r requirements/quality.txt
+py==1.11.0                # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pycodestyle==2.8.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.9.0           # via diff-cover
+pygments==2.11.2          # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
-pytest-cov==2.12.0        # via -r requirements/quality.txt
-pytest-django==4.3.0      # via -r requirements/quality.txt
+pytest-cov==2.12.1        # via -r requirements/quality.txt
+pytest-django==4.5.2      # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/quality.txt, edx-ace, xblock
+python-dateutil==2.8.2    # via -r requirements/quality.txt, edx-ace, xblock
 python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
-pytz==2021.1              # via -r requirements/quality.txt, django, fs, xblock
+pytz==2021.3              # via -r requirements/quality.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools, xblock
 requests==2.25.1          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov, sailthru-client
 sailthru-client==2.2.3    # via -r requirements/quality.txt, edx-ace
-simplejson==3.17.2        # via -r requirements/quality.txt, sailthru-client, xblock-utils
-six==1.16.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-ace, edx-i18n-tools, edx-lint, fs, mock, pathlib2, pip-tools, python-dateutil, stevedore, tox, virtualenv
-snowballstemmer==2.1.0    # via -r requirements/quality.txt, pydocstyle
-sqlparse==0.4.1           # via -r requirements/quality.txt, django
+simplejson==3.17.6        # via -r requirements/quality.txt, sailthru-client, xblock-utils
+six==1.16.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-ace, edx-lint, fs, mock, pathlib2, pip-tools, python-dateutil, stevedore, tox, virtualenv
+snowballstemmer==2.2.0    # via -r requirements/quality.txt, pydocstyle
+sqlparse==0.4.2           # via -r requirements/quality.txt, django
 stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-ace
 text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
-toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, coverage, pytest, tox
+toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, pytest-cov, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.23.1               # via -r requirements/travis.txt, tox-battery
+tox==3.24.5               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.3          # via -r requirements/quality.txt, astroid
 typing==3.7.4.3           # via -r requirements/quality.txt, fs
-urllib3==1.26.5           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-virtualenv==20.4.7        # via -r requirements/travis.txt, tox
-web-fragments==1.0.0      # via -r requirements/quality.txt, xblock, xblock-utils
+urllib3==1.26.8           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.13.3       # via -r requirements/travis.txt, tox
+web-fragments==2.0.0      # via -r requirements/quality.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/quality.txt, xblock
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-xblock-utils==2.1.3       # via -r requirements/quality.txt
-xblock==1.4.2             # via -r requirements/quality.txt, xblock-utils
+xblock-utils==3.0.0       # via -r requirements/quality.txt
+xblock==1.6.1             # via -r requirements/quality.txt, xblock-utils
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,71 +6,71 @@
 #
 appdirs==1.4.4            # via -r requirements/test.txt, fs
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==21.2.0             # via -r requirements/test.txt, edx-ace, pytest
+attrs==21.4.0             # via -r requirements/test.txt, edx-ace, pytest
 backports.functools-lru-cache==1.6.4  # via caniusepython3
 caniusepython3==7.3.0     # via -r requirements/quality.in
-certifi==2021.5.30        # via -r requirements/test.txt, requests
+certifi==2021.10.8        # via -r requirements/test.txt, requests
 chardet==4.0.0            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.txt
-coverage[toml]==5.5       # via -r requirements/test.txt, pytest-cov
-ddt==1.4.2                # via -r requirements/test.txt
-distlib==0.3.2            # via caniusepython3
+coverage==5.5             # via -r requirements/test.txt, pytest-cov
+ddt==1.4.4                # via -r requirements/test.txt
+distlib==0.3.4            # via caniusepython3
 django==2.2               # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, djangorestframework, edx-ace
 djangorestframework==3.12.4  # via -r requirements/test.txt
-edx-ace==0.1.17           # via -r requirements/test.txt
+edx-ace==1.1.0            # via -r requirements/test.txt
 edx-lint==1.5.2           # via -r requirements/quality.in
-fs==2.4.13                # via -r requirements/test.txt, xblock
-httpretty==1.1.3          # via -r requirements/test.txt
+fs==2.4.15                # via -r requirements/test.txt, xblock
+httpretty==1.1.4          # via -r requirements/test.txt
 idna==2.10                # via -r requirements/test.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.1.3  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2==2.11.3            # via -r requirements/test.txt, code-annotations
 lazy-object-proxy==1.4.3  # via astroid
-lxml==4.6.3               # via -r requirements/test.txt, xblock
-mako==1.1.4               # via -r requirements/test.txt, xblock-utils
+lxml==4.8.0               # via -r requirements/test.txt, xblock
+mako==1.1.6               # via -r requirements/test.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.txt
 packaging==20.9           # via -r requirements/test.txt, caniusepython3, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.6.0                # via -r requirements/test.txt, stevedore
+pathlib2==2.3.7.post1     # via -r requirements/test.txt, pytest
+pbr==5.8.1                # via -r requirements/test.txt, stevedore
 pillow==7.2.0             # via -r requirements/test.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.10.0                # via -r requirements/test.txt, pytest
-pycodestyle==2.7.0        # via -r requirements/quality.in, -r requirements/test.txt
+py==1.11.0                # via -r requirements/test.txt, pytest
+pycodestyle==2.8.0        # via -r requirements/quality.in, -r requirements/test.txt
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.12.0        # via -r requirements/test.txt
-pytest-django==4.3.0      # via -r requirements/test.txt
+pytest-cov==2.12.1        # via -r requirements/test.txt
+pytest-django==4.5.2      # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/test.txt, edx-ace, xblock
+python-dateutil==2.8.2    # via -r requirements/test.txt, edx-ace, xblock
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
-pytz==2021.1              # via -r requirements/test.txt, django, fs, xblock
+pytz==2021.3              # via -r requirements/test.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, xblock
 requests==2.25.1          # via -r requirements/test.txt, caniusepython3, sailthru-client
 sailthru-client==2.2.3    # via -r requirements/test.txt, edx-ace
-simplejson==3.17.2        # via -r requirements/test.txt, sailthru-client, xblock-utils
+simplejson==3.17.6        # via -r requirements/test.txt, sailthru-client, xblock-utils
 six==1.16.0               # via -r requirements/test.txt, astroid, edx-ace, edx-lint, fs, mock, pathlib2, python-dateutil, stevedore
-snowballstemmer==2.1.0    # via pydocstyle
-sqlparse==0.4.1           # via -r requirements/test.txt, django
+snowballstemmer==2.2.0    # via pydocstyle
+sqlparse==0.4.2           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-ace
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
-toml==0.10.2              # via -r requirements/test.txt, coverage, pytest
+toml==0.10.2              # via -r requirements/test.txt, pytest, pytest-cov
 typed-ast==1.4.3          # via astroid
 typing==3.7.4.3           # via -r requirements/test.txt, fs
-urllib3==1.26.5           # via -r requirements/test.txt, requests
-web-fragments==1.0.0      # via -r requirements/test.txt, xblock, xblock-utils
+urllib3==1.26.8           # via -r requirements/test.txt, requests
+web-fragments==2.0.0      # via -r requirements/test.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/test.txt, xblock
 wrapt==1.11.2             # via astroid
-xblock-utils==2.1.3       # via -r requirements/test.txt
-xblock==1.4.2             # via -r requirements/test.txt, xblock-utils
+xblock-utils==3.0.0       # via -r requirements/test.txt
+xblock==1.6.1             # via -r requirements/test.txt, xblock-utils
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,54 +5,54 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/base.txt, fs
-attrs==21.2.0             # via -r requirements/base.txt, edx-ace, pytest
-certifi==2021.5.30        # via -r requirements/base.txt, requests
+attrs==21.4.0             # via -r requirements/base.txt, edx-ace, pytest
+certifi==2021.10.8        # via -r requirements/base.txt, requests
 chardet==4.0.0            # via -r requirements/base.txt, requests
 click==7.1.2              # via code-annotations
 code-annotations==0.10.2  # via -r requirements/test.in
-coverage[toml]==5.5       # via pytest-cov
-ddt==1.4.2                # via -r requirements/test.in
+coverage==5.5             # via pytest-cov
+ddt==1.4.4                # via -r requirements/test.in
 djangorestframework==3.12.4  # via -r requirements/base.txt
-edx-ace==0.1.17           # via -r requirements/base.txt
-fs==2.4.13                # via -r requirements/base.txt, xblock
-httpretty==1.1.3          # via -r requirements/test.in
+edx-ace==1.1.0            # via -r requirements/base.txt
+fs==2.4.15                # via -r requirements/base.txt, xblock
+httpretty==1.1.4          # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==2.1.1  # via pluggy, pytest
+importlib-metadata==2.1.3  # via pluggy, pytest
 iniconfig==1.1.1          # via pytest
 jinja2==2.11.3            # via code-annotations
-lxml==4.6.3               # via -r requirements/base.txt, xblock
-mako==1.1.4               # via -r requirements/base.txt, xblock-utils
+lxml==4.8.0               # via -r requirements/base.txt, xblock
+mako==1.1.6               # via -r requirements/base.txt, xblock-utils
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, mako, xblock
 mock==3.0.5               # via -r requirements/test.in
 packaging==20.9           # via pytest
-pathlib2==2.3.5           # via pytest
-pbr==5.6.0                # via -r requirements/base.txt, stevedore
+pathlib2==2.3.7.post1     # via pytest
+pbr==5.8.1                # via -r requirements/base.txt, stevedore
 pillow==7.2.0             # via -r requirements/test.in
 pluggy==0.13.1            # via pytest
-py==1.10.0                # via pytest
-pycodestyle==2.7.0        # via -r requirements/test.in
+py==1.11.0                # via pytest
+pycodestyle==2.8.0        # via -r requirements/test.in
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.12.0        # via -r requirements/test.in
-pytest-django==4.3.0      # via -r requirements/test.in
+pytest-cov==2.12.1        # via -r requirements/test.in
+pytest-django==4.5.2      # via -r requirements/test.in
 pytest==6.1.2             # via pytest-cov, pytest-django
-python-dateutil==2.8.1    # via -r requirements/base.txt, edx-ace, xblock
+python-dateutil==2.8.2    # via -r requirements/base.txt, edx-ace, xblock
 python-slugify==4.0.1     # via code-annotations
-pytz==2021.1              # via -r requirements/base.txt, django, fs, xblock
+pytz==2021.3              # via -r requirements/base.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, xblock
 requests==2.25.1          # via -r requirements/base.txt, sailthru-client
 sailthru-client==2.2.3    # via -r requirements/base.txt, edx-ace
-simplejson==3.17.2        # via -r requirements/base.txt, sailthru-client, xblock-utils
+simplejson==3.17.6        # via -r requirements/base.txt, sailthru-client, xblock-utils
 six==1.16.0               # via -r requirements/base.txt, edx-ace, fs, mock, pathlib2, python-dateutil, stevedore
-sqlparse==0.4.1           # via -r requirements/base.txt, django
+sqlparse==0.4.2           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-ace
 text-unidecode==1.3       # via python-slugify
-toml==0.10.2              # via coverage, pytest
+toml==0.10.2              # via pytest, pytest-cov
 typing==3.7.4.3           # via -r requirements/base.txt, fs
-urllib3==1.26.5           # via -r requirements/base.txt, requests
-web-fragments==1.0.0      # via -r requirements/base.txt, xblock, xblock-utils
+urllib3==1.26.8           # via -r requirements/base.txt, requests
+web-fragments==2.0.0      # via -r requirements/base.txt, xblock, xblock-utils
 webob==1.8.7              # via -r requirements/base.txt, xblock
-xblock-utils==2.1.3       # via -r requirements/base.txt
-xblock==1.4.2             # via -r requirements/base.txt, xblock-utils
+xblock-utils==3.0.0       # via -r requirements/base.txt
+xblock==1.6.1             # via -r requirements/base.txt, xblock-utils
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-certifi==2021.5.30        # via requests
+certifi==2021.10.8        # via requests
 chardet==4.0.0            # via requests
-codecov==2.1.11           # via -r requirements/travis.in
+codecov==2.1.12           # via -r requirements/travis.in
 coverage==5.5             # via codecov
-distlib==0.3.2            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
+distlib==0.3.4            # via virtualenv
+filelock==3.2.1           # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
+importlib-metadata==2.1.3  # via pluggy, tox, virtualenv
 importlib-resources==3.2.1  # via virtualenv
 packaging==20.9           # via tox
+platformdirs==2.0.2       # via virtualenv
 pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
+py==1.11.0                # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.25.1          # via codecov
 six==1.16.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.23.1               # via -r requirements/travis.in, tox-battery
-urllib3==1.26.5           # via requests
-virtualenv==20.4.7        # via tox
+tox==3.24.5               # via -r requirements/travis.in, tox-battery
+urllib3==1.26.8           # via requests
+virtualenv==20.13.3       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
This small PR updates the edx-ace version to match that of edx-platform and includes other changes that were a result of running `make upgrade` command.