### PR TITLE
[BB-6055] Add masters track to auto verify

### DIFF
--- a/custom_student_verification/signals.py
+++ b/custom_student_verification/signals.py
@@ -70,5 +70,5 @@ def auto_verify_paid_students(sender, instance, created, **kwargs):  # pylint: d
     """
     course_mode = get_course_mode_model()
     if settings.FEATURES.get('ENABLE_PAID_COURSE_AUTO_VERIFY'):
-        if instance.mode == course_mode.VERIFIED:
+        if instance.mode == course_mode.VERIFIED or instance.mode == course_mode.MASTERS:
             approve_user(instance.user, 'auto-verification')

--- a/custom_student_verification/signals.py
+++ b/custom_student_verification/signals.py
@@ -42,8 +42,9 @@ def approve_user(user, reason):
             reason=reason if reason else 'N/A',
             name=user.profile.name
         )
-        # send an email to the user about verification approval.
-        send_verification_approved_email(user, reason)
+        if not settings.FEATURES.get('DISABLE_VERIFICATION_EMAIL_NOTIFICATION'):
+            # send an email to the user about verification approval.
+            send_verification_approved_email(user, reason)
 
 
 def reject_user(user, reason):
@@ -56,8 +57,9 @@ def reject_user(user, reason):
     ManualVerification = get_manual_verification_model()
     # delete all approved ManualVerification records for user.
     ManualVerification.objects.filter(user=user, status='approved').delete()
-    # send an email to the user about verification rejection.
-    send_verification_rejected_email(user, reason)
+    if not settings.FEATURES.get('DISABLE_VERIFICATION_EMAIL_NOTIFICATION'):
+        # send an email to the user about verification rejection.
+        send_verification_rejected_email(user, reason)
 
 
 @receiver(post_save, sender=get_course_enrollment_model())

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -93,3 +93,7 @@ Copy ``lms/templates/verify_student/reverify_not_allowed.html`` from the `edx-pl
 
 If we set `ENABLE_PAID_COURSE_AUTO_VERIFY` to `True` in `/edx/etc/lms.yml`, this will automatically verify a user if they are enrolled
 in any paid courses.
+
+## Disable Email Notification
+
+Set `DISABLE_VERIFICATION_EMAIL_NOTIFICATION` to `True` under `FEATURES` option in `/edx/etc/lms.yml` to disable sending email notification to users on approval or rejection. This defaults to `False` so it doesn't break existing flow.

--- a/test_settings.py
+++ b/test_settings.py
@@ -28,6 +28,10 @@ DATABASES = {
     }
 }
 
+FEATURES = {
+    'DISABLE_VERIFICATION_EMAIL_NOTIFICATION': False,
+}
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.admin',


### PR DESCRIPTION
This PR enables the auto verification for Master's course mode and adds a flag to disable email notifications for verification approval or rejection.

**Jira Tickets:** [BB-6055](https://tasks.opencraft.com/browse/BB-6055)

**Testing Instructions:**
1. Deploy this branch and set up master's course mode.
2. Set `ENABLE_PAID_COURSE_AUTO_VERIFY` to `true` and verify that users enrolled in masters mode are auto verified.
3. Set `DISABLE_VERIFICATION_EMAIL_NOTIFICATION` to `true` and verify that users aren't getting email notification on verification.
